### PR TITLE
fix: include already-downloaded tracks in Plex playlist sync

### DIFF
--- a/src/main/kotlin/dpozinen/music/sockseek/SockseekClient.kt
+++ b/src/main/kotlin/dpozinen/music/sockseek/SockseekClient.kt
@@ -56,6 +56,7 @@ data class SockseekJobSummary(
 	val kind: String,
 	val lifecycleState: String,
 	val terminalOutcome: String? = null,
+	val skipReason: String? = null,
 	val parentJobId: String? = null,
 )
 
@@ -63,11 +64,14 @@ data class SockseekJobSummary(
 data class SockseekPayload(
 	val downloadPath: String? = null,
 	val downloadSource: String? = null,
+	val skipReason: String? = null,
 )
 
 object SockseekStates {
 	const val TERMINAL = "Terminal"
 	const val SONG = "song"
 	const val SUCCEEDED = "Succeeded"
+	const val SKIPPED = "Skipped"
 	const val SOULSEEK = "Soulseek"
+	const val ALREADY_EXISTS = "AlreadyExists"
 }

--- a/src/main/kotlin/dpozinen/music/sockseek/SockseekHarvester.kt
+++ b/src/main/kotlin/dpozinen/music/sockseek/SockseekHarvester.kt
@@ -10,12 +10,13 @@ class SockseekHarvester(private val sockseek: SockseekClient) {
 	fun resolve(extractJobId: String): List<String> {
 		val workflowId = sockseek.getJob(extractJobId).summary.workflowId
 		val songs = sockseek.getJobs(workflowId, includeAll = true)
-			.filter { it.kind == SockseekStates.SONG && it.terminalOutcome == SockseekStates.SUCCEEDED }
+			.filter { it.kind == SockseekStates.SONG }
+			.filter { it.terminalOutcome == SockseekStates.SUCCEEDED || it.skipReason == SockseekStates.ALREADY_EXISTS }
 		val paths = songs
 			.mapNotNull { sockseek.getJob(it.jobId).payload }
-			.filter { it.downloadSource == SockseekStates.SOULSEEK }
+			.filter { it.downloadSource == SockseekStates.SOULSEEK || it.skipReason == SockseekStates.ALREADY_EXISTS }
 			.mapNotNull { it.downloadPath }
-		log.info { "Workflow $workflowId (job $extractJobId): ${songs.size} succeeded songs, ${paths.size} soulseek downloads" }
+		log.info { "Workflow $workflowId (job $extractJobId): ${songs.size} succeeded/existing songs, ${paths.size} resolved paths" }
 		return paths
 	}
 }


### PR DESCRIPTION
SockseekHarvester was filtering only SUCCEEDED+Soulseek songs, silently dropping Skipped/AlreadyExists jobs which sockseek emits for tracks that are already on disk. Those jobs carry a valid downloadPath, so excluding them caused PlexPlaylistSyncer to see 0 resolved tracks and wipe every playlist on restart or re-sync.